### PR TITLE
fix(0.3.0): missing `app.quit()` when `window-all-closed`

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -41,6 +41,7 @@ function createWindow() {
 
 app.on('window-all-closed', () => {
   win = null
+  if (process.platform !== 'darwin') app.quit()
 })
 
 app.whenReady().then(createWindow)


### PR DESCRIPTION
Fixes #21 