### PR TITLE
fix: resolve Build app does not load properly npm run build  #29

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -43,7 +43,7 @@ function createWindow() {
     win.loadURL(VITE_DEV_SERVER_URL)
   } else {
     // win.loadFile('dist/index.html')
-    win.loadFile(path.join(RENDERER_DIST, 'index.html'))
+    win.loadFile('index.html')
   }
 }
 

--- a/electron/package.json
+++ b/electron/package.json
@@ -3,6 +3,7 @@
     "electron": "^30.0.1",
     "electron-builder": "^24.13.3",
     "vite-plugin-electron": "^0.28.6",
-    "vite-plugin-electron-renderer": "^0.14.5"
+    "vite-plugin-electron-renderer": "^0.14.5",
+    "vite-plugin-static-copy": "^1.0.5"
   }
 }


### PR DESCRIPTION
The reason why the initial application cannot be built now may be as follows:

(1)remove [workspace-path]\dist-app\win-unpacked\d3dcompiler_47.dll: Access is denied. This is because the file is occupied by [workspace-path]\dist-app\win-unpacked\[app].exe.
 Just restart the computer or use other methods to unblock it.

(2)C:\Users\[user name]\AppData\Local\electron-builder\Cache\nsis\nsis-3.0.4.1\Bin\makensis.exe process failed ERR_ELECTRON_BUILDER_CANNOT_EXECUTE Exit code: 1
When this error occurs, the application has completed packaging, but the installation package failed to be packaged.
This problem occurs when using pnpm, but there is no problem using npm.
After installing Electron-build globally, enter the dist folder and run Electron-build to solve the problem.

(3)Application entry file "main.js" in the "[workspace-path]\dist-app\win-unpacked\resources\app.asar" does not exist. Seems like a wrong configuration. This is because the copy plug-in does not correctly put main.js and preload.mjs into the dist folder.
Running "build" in "scripts" again will solve the problem.