### PR TITLE
chore(deps): update vue-tsc to v2

### DIFF
--- a/template-vue-ts/package.json
+++ b/template-vue-ts/package.json
@@ -15,6 +15,6 @@
     "@vitejs/plugin-vue": "^5.0.4",
     "typescript": "^5.2.2",
     "vite": "^5.1.6",
-    "vue-tsc": "^1.8.27"
+    "vue-tsc": "^2.0.26"
   }
 }


### PR DESCRIPTION
The v1 version of vue-tsc encounters an error：`...Search string not found: "for (const existingRoot of buildInfoVersionMap.roots) {"...` during execution and requires an upgrade to v2. For more details, please refer to: https://github.com/vuejs/language-tools/issues/4484